### PR TITLE
Change to a protocol-less URI for jQuery library

### DIFF
--- a/lib/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/hooks/view_layouts_base_html_head_hook.rb
@@ -2,13 +2,12 @@ module RedmineLightBox
   module Hooks
     class ViewLayoutsBaseHtmlHeadHook < Redmine::Hook::ViewListener
       def view_layouts_base_html_head(context={})
-        protocol = context[:request].ssl? ? 'https' : 'http'
         if context[:controller] && (  context[:controller].is_a?(IssuesController) || 
                                       context[:controller].is_a?(WikiController) ||
                                       context[:controller].is_a?(BoardsController))
           return stylesheet_link_tag("jquery.fancybox-1.3.4.css", :plugin => "redmine_lightbox", :media => "screen") +
             stylesheet_link_tag("lightbox.css", :plugin => "redmine_lightbox", :media => "screen") +
-            javascript_include_tag(protocol+'://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js') +
+            javascript_include_tag('//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js') +
             javascript_tag('jQuery.noConflict();') +
             javascript_include_tag('jquery.fancybox-1.3.4.pack.js', :plugin => 'redmine_lightbox') +
             javascript_include_tag('jquery.easing-1.3.pack.js', :plugin => 'redmine_lightbox') +            


### PR DESCRIPTION
The protocol check is not needed when the only part of the URI that changes is the protocol.

Can simply use _//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js_ as the src attribute and it will work in both HTTP and HTTPS cases.

Reference: [section 4.2 of RFC 3986](http://tools.ietf.org/html/rfc3986#section-4.2)
